### PR TITLE
Fix the name of the CodeMirror example in package*.json

### DIFF
--- a/codemirror/package-lock.json
+++ b/codemirror/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "yjs-demos-prosemirror",
+  "name": "yjs-demos-codemirror",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/codemirror/package.json
+++ b/codemirror/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "yjs-demos-prosemirror",
+  "name": "yjs-demos-codemirror",
   "version": "1.0.0",
-  "description": "Yjs ProseMirror editor binding demo",
+  "description": "Yjs CodeMirror editor binding demo",
   "main": "index.js",
   "scripts": {
     "dist": "webpack --mode=production",


### PR DESCRIPTION
Minor thing, but just noticed the name is wrong. Wanted to contribute another, more specialized example based on this one and that's why I noticed :)