### PR TITLE
Enable offline persistence in TipTap demo

### DIFF
--- a/tiptap/package-lock.json
+++ b/tiptap/package-lock.json
@@ -11732,6 +11732,14 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
+    "y-indexeddb": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/y-indexeddb/-/y-indexeddb-9.0.3.tgz",
+      "integrity": "sha512-nrQPR2oocEAdvAIvgJ06TMg/UTepEoYRqUmL/T03nG87Angvs7b3AAysd1ChMfAKoJujzVHWA3nKWkp0Eiu7/Q==",
+      "requires": {
+        "lib0": "^0.2.12"
+      }
+    },
     "y-prosemirror": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-0.3.3.tgz",

--- a/tiptap/package.json
+++ b/tiptap/package.json
@@ -16,6 +16,7 @@
     "tiptap": "^1.26.6",
     "tiptap-extensions": "^1.28.6",
     "vue": "^2.6.11",
+    "y-indexeddb": "^9.0.3",
     "y-prosemirror": "^0.3.3",
     "y-websocket": "^1.2.4",
     "yjs": "^13.0.4"

--- a/tiptap/src/Realtime.js
+++ b/tiptap/src/Realtime.js
@@ -2,10 +2,12 @@ import { keymap } from 'prosemirror-keymap'
 import { Extension } from 'tiptap'
 import { redo, undo, yCursorPlugin, ySyncPlugin, yUndoPlugin } from 'y-prosemirror'
 import { WebsocketProvider } from 'y-websocket'
+import { IndexeddbPersistence } from 'y-indexeddb'                             // Remove this in case you don't want offline persistence
 import * as Y from 'yjs'
 
 const ydoc = new Y.Doc()
 const provider = new WebsocketProvider('wss://demos.yjs.dev', 'tiptap', ydoc)
+const indexeddbProvider = new IndexeddbPersistence('tiptap', ydoc)              // Remove this in case you don't want offline persistence
 const type = ydoc.getXmlFragment('prosemirror')
 
 export default class RealtimeExtension extends Extension {


### PR DESCRIPTION
With this, the TipTap demo will continue to function even in case of a network disconnect. Referenced from #29.

