### PR TITLE
Added Gitpod Config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: npm install
+    command: npm run start
+ports:
+  - port: 8080
+    onOpen: open-preview


### PR DESCRIPTION
This PR adds a small config to the project, that tells Gitpod how to prepare the workspaces. 
If you enable prebuilds the init task will be executed asynchronously when someone pushes a branch. As a result you can spin up a dev environments in a few seconds that ran already through the `npm install` step and immediately shows the demo in the preview on the right.

You can see the effect on my fork:
gitpod.io#https://github.com/svenefftinge/yjs-demos