### PR TITLE
Fix `codemirror.css` stylesheet address

### DIFF
--- a/codemirror/codemirror.html
+++ b/codemirror/codemirror.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Yjs CodeMirror Example</title>
     <script type="text/javascript" src="./dist/codemirror.bundle.js" async></script>
-    <link rel=stylesheet href="https://codemirror.net/lib/codemirror.css"  async defer>
+    <link rel=stylesheet href="https://codemirror.net/5/lib/codemirror.css"  async defer>
     <style>
       .remote-caret {
         position: relative;


### PR DESCRIPTION
Project `codemirror` v5 changed all the urls adding `5` infix. So the live demo shows nothing now because styles are not loaded. I consider this fix as a workaround through, because I believe it is recommended to use local copy of `codemirror.css` or use third-party repositories. Another opportunity is to link directly so some github commit of the file.