### PR TITLE
Fix title and link of README.md

### DIFF
--- a/codemirror/README.md
+++ b/codemirror/README.md
@@ -1,7 +1,7 @@
-# ProseMirror Demo
+# CodeMirror 5 Demo
 > [y-codemirror](https://docs.yjs.dev/ecosystem/editor-bindings/codemirror) / [y-websocket](https://docs.yjs.dev/ecosystem/connection-provider/y-websocket) / [Live Demo](https://demos.yjs.dev/codemirror/codemirror.html)
 
-This is a demo of a [CodeMirror 5](https://codemirror.net/) editor that was made collaborative with Yjs & y-codemirror.
+This is a demo of a [CodeMirror 5](https://codemirror.net/5/) editor that was made collaborative with Yjs & y-codemirror.
 
 We use the [y-websocket](https://docs.yjs.dev/ecosystem/connection-provider) provider to share document updates through a server. There are many more providers available for Yjs - try switching to another provider. [See docs](https://docs.yjs.dev/ecosystem/connection-provider).
 


### PR DESCRIPTION
Change title from incorrect "ProseMirror" to correct "CodeMirror 5" and fix link to CodeMirror 5 site, it is moved to `codemirror.net/5` directory.