### PR TITLE
Show snapshots issue with y-websocket

### DIFF
--- a/prosemirror-versions/prosemirror-versions.js
+++ b/prosemirror-versions/prosemirror-versions.js
@@ -143,7 +143,7 @@ window.addEventListener('load', () => {
   const permanentUserData = new Y.PermanentUserData(ydoc)
   permanentUserData.setUserMapping(ydoc, ydoc.clientID, user.username)
   ydoc.gc = false
-  const provider = new WebsocketProvider('wss://demos.yjs.dev', 'prosemirror-versions-demo', ydoc)
+  const provider = new WebsocketProvider('ws://localhost:1234', 'prosemirror-versions-demo', ydoc)
   const yXmlFragment = ydoc.get('prosemirror', Y.XmlFragment)
 
   const editor = document.createElement('div')


### PR DESCRIPTION
To reproduce:

1. Install dependencies: `npm i`
2. Start local y-websocket server: `HOST=localhost PORT=1234 npx y-websocket`
3. Run project: `npm start`
4. Observe that captured snapshots work until you refresh the page:

https://github.com/yjs/yjs-demos/assets/6430933/89d9d31a-1502-439e-bc76-1250cd50e054



