### PR TITLE
Fix typos

### DIFF
--- a/codemirror.next/README.md
+++ b/codemirror.next/README.md
@@ -5,7 +5,7 @@ This is a demo of a [CodeMirror 6](https://codemirror.net/) editor that was made
 
 We use the [y-websocket](https://docs.yjs.dev/ecosystem/connection-provider) provider to share document updates through a server. There are many more providers available for Yjs - try switching to another provider. [See docs](https://docs.yjs.dev/ecosystem/connection-provider).
 
-Also you could try addingh offline persistence to this demo. Wouldn't it be cool if document updates are persisted in the browser, so you can load your application load faster? Try it out: https://docs.yjs.dev/getting-started/allowing-offline-editing
+Also you could try adding offline persistence to this demo. Wouldn't it be cool if document updates are persisted in the browser, so you can load your application load faster? Try it out: https://docs.yjs.dev/getting-started/allowing-offline-editing
 
 ## Quick Start
 

--- a/codemirror/README.md
+++ b/codemirror/README.md
@@ -5,7 +5,7 @@ This is a demo of a [CodeMirror 5](https://codemirror.net/5) editor that was mad
 
 We use the [y-websocket](https://docs.yjs.dev/ecosystem/connection-provider) provider to share document updates through a server. There are many more providers available for Yjs - try switching to another provider. [See docs](https://docs.yjs.dev/ecosystem/connection-provider).
 
-Also you could try addingh offline persistence to this demo. Wouldn't it be cool if document updates are persisted in the browser, so you can load your application load faster? Try it out: https://docs.yjs.dev/getting-started/allowing-offline-editing
+Also you could try adding offline persistence to this demo. Wouldn't it be cool if document updates are persisted in the browser, so you can load your application load faster? Try it out: https://docs.yjs.dev/getting-started/allowing-offline-editing
 
 ## Quick Start
 

--- a/codemirror/README.md
+++ b/codemirror/README.md
@@ -1,4 +1,4 @@
-# ProseMirror Demo
+# CodeMirror Demo
 > [y-codemirror](https://docs.yjs.dev/ecosystem/editor-bindings/codemirror) / [y-websocket](https://docs.yjs.dev/ecosystem/connection-provider/y-websocket) / [Live Demo](https://demos.yjs.dev/codemirror/codemirror.html)
 
 This is a demo of a [CodeMirror 5](https://codemirror.net/5) editor that was made collaborative with Yjs & y-codemirror. Note that CodeMirror 6 is now the latest release. 

--- a/prosemirror/README.md
+++ b/prosemirror/README.md
@@ -5,7 +5,7 @@ This is a demo of a [ProseMirror](https://prosemirror.net/) editor that was made
 
 We use the [y-websocket](https://docs.yjs.dev/ecosystem/connection-provider/y-websocket) provider to share document updates through a server. There are many more providers available for Yjs - try switching to another provider. [See docs](https://docs.yjs.dev/ecosystem/connection-provider).
 
-Also you could try addingh offline persistence to this demo. Wouldn't it be cool if document updates are persisted in the browser, so you can load your application load faster? Try it out: https://docs.yjs.dev/getting-started/allowing-offline-editing
+Also you could try adding offline persistence to this demo. Wouldn't it be cool if document updates are persisted in the browser, so you can load your application load faster? Try it out: https://docs.yjs.dev/getting-started/allowing-offline-editing
 
 ## Quick Start
 


### PR DESCRIPTION
Change"ProseMirror" to "CodeMirror" in CodeMirror example docs.

Change "addingh" to "adding" in ProseMirror and CodeMirror docs.